### PR TITLE
Graph labels optimisation for readability

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -17,19 +17,19 @@ export const sharedPageComponents: SharedLayout = {
 // components for pages that display a single page (e.g. a single note)
 export const defaultContentPageLayout: PageLayout = {
   beforeBody: [
-    // Component.ArticleTitle(), // off for now 
+    // Component.ArticleTitle(), // off for now
     Component.Graph({
       localGraph: {
         // THIS is the default graph - not the full screen
         drag: true, // whether to allow panning the view around
         zoom: true, // whether to allow zooming in and out
-        depth: 2, // how many hops of notes to display
-        scale: 1.5, // default view scale
+        depth: 2.5, // how many hops of notes to display
+        scale: 2.5, // default view scale
         repelForce: 0.8, // how much nodes should repel each other
         centerForce: 0.4, // how much force to use when trying to center the nodes
         linkDistance: 80, // how long should the links be by default?
-        fontSize: 0.8, // what size should the node labels be?
-        opacityScale: 10, // how quickly do we fade out the labels when zooming out?
+        fontSize: 0.9, // what size should the node labels be?
+        opacityScale: 0, // how quickly do we fade out the labels when zooming out?
         removeTags: [], // what tags to remove from the graph
         showTags: true, // whether to show tags in the graph
         focusOnHover: true,
@@ -43,7 +43,7 @@ export const defaultContentPageLayout: PageLayout = {
         centerForce: 0.4, // how much force to use when trying to center the nodes
         linkDistance: 180, // how long should the links be by default?
         fontSize: 0.8, // what size should the node labels be?
-        opacityScale: 1, // how quickly do we fade out the labels when zooming out?
+        opacityScale: 0, // how quickly do we fade out the labels when zooming out?
         removeTags: [], // what tags to remove from the graph
         showTags: true, // whether to show tags in the graph
         focusOnHover: true,
@@ -73,11 +73,11 @@ export const defaultListPageLayout: PageLayout = {
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
-    
+
     Component.Darkmode(),
     // Component.DesktopOnly(Component.Explorer()),
     Component.DesktopOnly(Component.TableOfContents()),
-    Component.Backlinks()
+    Component.Backlinks(),
   ],
   right: [],
 }

--- a/quartz/components/Landing.tsx
+++ b/quartz/components/Landing.tsx
@@ -12,13 +12,13 @@ export default (() => {
     localGraph: {
       drag: true,  // Disable dragging in the local graph
       zoom: true,
-      depth: 2,     // Increase the depth for the local graph
+      depth: 2.5,     // Increase the depth for the local graph
       scale: 1.5,
       repelForce: 0.8,
       centerForce: 0.4,
-      linkDistance: 50,
+      linkDistance: 25,
       fontSize: 0.8,
-      opacityScale: 10, // high opacity makes node text show with slightest graph interaction
+      opacityScale: 0.9, // high opacity makes node text show with slightest graph interaction
       removeTags: [],
       showTags: true,
       focusOnHover: true,
@@ -26,7 +26,7 @@ export default (() => {
     globalGraph: {
       drag: true,
       zoom: true,
-      depth: 3,     // Set depth for the global graph
+      depth: 4,     // Set depth for the global graph
       scale: 0.8,
       repelForce: 0.6,
       centerForce: 0.4,

--- a/quartz/components/Landing.tsx
+++ b/quartz/components/Landing.tsx
@@ -13,12 +13,12 @@ export default (() => {
       drag: true,  // Disable dragging in the local graph
       zoom: true,
       depth: 2.5,     // Increase the depth for the local graph
-      scale: 1.5,
+      scale: 2.5,
       repelForce: 0.8,
       centerForce: 0.4,
-      linkDistance: 25,
-      fontSize: 0.8,
-      opacityScale: 0.9, // high opacity makes node text show with slightest graph interaction
+      linkDistance: 70,
+      fontSize: 0.9,
+      opacityScale: 0, // high opacity makes node text show with slightest graph interaction
       removeTags: [],
       showTags: true,
       focusOnHover: true,
@@ -32,7 +32,7 @@ export default (() => {
       centerForce: 0.4,
       linkDistance: 50,
       fontSize: 0.6, 
-      opacityScale: 1,
+      opacityScale: 0,
       removeTags: [],
       showTags: true,
       focusOnHover: true,

--- a/quartz/components/Landing.tsx
+++ b/quartz/components/Landing.tsx
@@ -46,7 +46,7 @@ export default (() => {
 
   function Landing(componentData: QuartzComponentProps) {
     return (
-      <>
+      <div className='landing-page'>
         <nav className="navbar" style={{
           boxShadow: 'var(--shadow)',
           borderBottom: '1px solid var(--lightgray)',
@@ -304,7 +304,7 @@ export default (() => {
             <FooterComponent {...componentData} />
           </div>
         </section>
-      </>
+      </div>
     )
   }
 

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -209,7 +209,6 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     ).length
     return 3 + Math.sqrt(numLinks)
   }
-
   let hoveredNodeId: string | null = null
   let hoveredNeighbours: Set<string> = new Set()
   const linkRenderData: LinkRenderData[] = []
@@ -273,6 +272,26 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     })
   }
 
+  function renderInitialLabels() {
+    const currentNode = nodeRenderData[0]
+    const currentNodeId = currentNode.simulationData.id
+    const neighboringNodeIds = new Set(
+      graphData.links
+        .filter((link) => link.source.id === currentNodeId || link.target.id === currentNodeId)
+        .flatMap((link) => [link.source.id, link.target.id]),
+    )
+    for (const n of nodeRenderData) {
+      const nodeId = n.simulationData.id
+
+      if (neighboringNodeIds.has(nodeId)) {
+        n.label.alpha = 1
+
+        const defaultScale = 1 / scale
+        n.label.scale.set(defaultScale)
+      }
+    }
+  }
+
   function renderLabels() {
     tweens.get("label")?.stop()
     const tweenGroup = new TweenGroup()
@@ -282,7 +301,6 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     for (const n of nodeRenderData) {
       const nodeId = n.simulationData.id
       const isActive = nodeId === hoveredNodeId || hoveredNeighbours.has(nodeId)
-
       if (isActive) {
         tweenGroup.add(
           new Tweened<Text>(n.label).to(
@@ -431,6 +449,8 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
 
     nodeRenderData.push(nodeRenderDatum)
   }
+
+  renderInitialLabels()
 
   for (const l of graphData.links) {
     const gfx = new Graphics({ interactive: false, eventMode: "none" })

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -285,7 +285,6 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
 
       if (neighboringNodeIds.has(nodeId)) {
         n.label.alpha = 1
-
         const defaultScale = 1 / scale
         n.label.scale.set(defaultScale)
       }
@@ -300,8 +299,7 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     const activeScale = defaultScale * 1.1
     for (const n of nodeRenderData) {
       const nodeId = n.simulationData.id
-      const isActive = nodeId === hoveredNodeId || hoveredNeighbours.has(nodeId)
-      if (isActive) {
+      if (hoveredNodeId === nodeId) {
         tweenGroup.add(
           new Tweened<Text>(n.label).to(
             {
@@ -315,7 +313,7 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
         tweenGroup.add(
           new Tweened<Text>(n.label).to(
             {
-              alpha: 0,
+              alpha: n.label.alpha,
               scale: { x: defaultScale, y: defaultScale },
             },
             100,
@@ -527,16 +525,17 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           stage.scale.set(transform.k, transform.k)
           stage.position.set(transform.x, transform.y)
 
+          // Removed for keeping initially rendered labels when zooming/ dragging
           // zoom adjusts opacity of labels too
-          const scale = transform.k * opacityScale
-          let scaleOpacity = Math.max((scale - 1) / 3.75, 0)
-          const activeNodes = nodeRenderData.filter((n) => n.active).flatMap((n) => n.label)
+          // const scale = transform.k * opacityScale
+          // let scaleOpacity = Math.max((scale - 1) / 3.75)
+          // const activeNodes = nodeRenderData.filter((n) => n.active).flatMap((n) => n.label)
 
-          for (const label of labelsContainer.children) {
-            if (!activeNodes.includes(label)) {
-              label.alpha = scaleOpacity
-            }
-          }
+          // for (const label of labelsContainer.children) {
+          //   if (!activeNodes.includes(label)) {
+          //     label.alpha = scaleOpacity
+          //   }
+          // }
         }),
     )
   }

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -207,7 +207,7 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     const numLinks = graphData.links.filter(
       (l) => l.source.id === d.id || l.target.id === d.id,
     ).length
-    return 20 + Math.sqrt(numLinks)
+    return 3 + Math.sqrt(numLinks)
   }
 
   let hoveredNodeId: string | null = null
@@ -281,8 +281,9 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     const activeScale = defaultScale * 1.1
     for (const n of nodeRenderData) {
       const nodeId = n.simulationData.id
+      const isActive = nodeId === hoveredNodeId || hoveredNeighbours.has(nodeId)
 
-      if (hoveredNodeId === nodeId) {
+      if (isActive) {
         tweenGroup.add(
           new Tweened<Text>(n.label).to(
             {
@@ -296,7 +297,7 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
         tweenGroup.add(
           new Tweened<Text>(n.label).to(
             {
-              alpha: n.label.alpha,
+              alpha: 0,
               scale: { x: defaultScale, y: defaultScale },
             },
             100,


### PR DESCRIPTION
- Primary child node labels are now being rendered initially with `renderInitialLabels`
- Removed all labels on zoom except for the initial labels to help with readability.
- Modified quartz graph configurations for readability